### PR TITLE
Remove Selfbot Tag from Klasa

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Built-in features marked as `✓` means they exist and are modifiable, `✘` mea
 | Modifiable built-in command handler | ✓ | ? | ✓ | ✓ | ✓ | ? |
 | Modifiable built-in responses | ✓ ⇒ ∅ | ✘ | ✓ | ✓ | ✘ | ✓ |
 | Modifiable built-in locales | ∅ | ∅ | ∅ | ✓ | ∅ | ✓ |
-| Selfbot mode | ✓ | ✓ | ∅ | ∅ | ✓ | ✓ |
+| Selfbot mode | ✓ | ✓ | ∅ | ✓ ⇒ ∅ | ✓ | ✓ |
 | Bot owner | ✓ | ✓ | ∅ | ✓ | ✓ | ✓ |
 | Multiple owners | ✓ | ✓ | ∅ | ✓ | ✓ | ✓ |
 | Module directories | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Built-in features marked as `✓` means they exist and are modifiable, `✘` mea
 | Modifiable built-in command handler | ✓ | ? | ✓ | ✓ | ✓ | ? |
 | Modifiable built-in responses | ✓ ⇒ ∅ | ✘ | ✓ | ✓ | ✘ | ✓ |
 | Modifiable built-in locales | ∅ | ∅ | ∅ | ✓ | ∅ | ✓ |
-| Selfbot mode | ✓ | ✓ | ∅ | ✓ | ✓ | ✓ |
+| Selfbot mode | ✓ | ✓ | ∅ | ∅ | ✓ | ✓ |
 | Bot owner | ✓ | ✓ | ∅ | ✓ | ✓ | ✓ |
 | Multiple owners | ✓ | ✓ | ∅ | ✓ | ✓ | ✓ |
 | Module directories | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |


### PR DESCRIPTION
Klasa has removed Selfbot ability after Discord.JS removed it on their Master branch.
To be very honest the whole Selfbot row should be removed considering Discord has discouraged it a lot already.