### PR TITLE
Bump Klasa's NodeJS version to v10.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Dependencies do not include Discord.js, TypeScript, or optional/peer dependencie
 | --- | :-: | :-: | :-: | :-: | :-: |
 | Library version | 7.5.5 | 0.10.0 | 0.4.0 | 0.21.1 | 3.0.1 |
 | Discord.js version | `^11.4.0` | `^11.2.1` | Master branch | Master branch | Custom 11.1 |
-| Node.js version | 6.0.0 | 7.0.0 | 8.5.0 | 8.5.0 | 8.0.0 |
+| Node.js version | 6.0.0 | 7.0.0 | 10.1.0 | 8.5.0 | 8.0.0 |
 | Typings | ✓ | ✓ | ✓ | ✘ | ✓ †1 |
 | Dependencies | 0 | 3 | 2 | 4 | 5 |
 | Documentation | [Akairo](https://1computer1.github.io/discord-akairo/) | [Commando](https://discord.js.org/#/docs/commando/master/general/welcome) | [Klasa](https://klasa.js.org/) | [Komada](https://komada.js.org/) | [YAMDBF](https://yamdbf.js.org/) |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Dependencies do not include Discord.js, TypeScript, or optional/peer dependencie
 
 | **General** | [**Akairo**][akairo] | [**Commando**][commando] | [**Klasa**][klasa] | [**Komada**][komada] | [**YAMDBF**][yamdbf] |
 | --- | :-: | :-: | :-: | :-: | :-: |
-| Library version | 7.5.5 | 0.10.0 | 0.4.0 | 0.21.1 | 3.0.1 |
+| Library version | 7.5.5 | 0.10.0 | 0.5.0 | 0.21.1 | 3.0.1 |
 | Discord.js version | `^11.4.0` | `^11.2.1` | Master branch | Master branch | Custom 11.1 |
 | Node.js version | 6.0.0 | 7.0.0 | 10.1.0 | 8.5.0 | 8.0.0 |
 | Typings | ✓ | ✓ | ✓ | ✘ | ✓ †1 |


### PR DESCRIPTION
* Klasa now requires node v10.1.0 to run cuz of fs-nextra.

* Source: https://github.com/dirigeants/klasa/blob/3360292f349cc791063a6b4dcb709080c486a1d8/package.json#L39