### PR TITLE
chore: remove komada and klasa

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ Discord.js versions are noted in semver where applicable.
 Node.js versions are the minimum versions required.  
 Dependencies do not include Discord.js, TypeScript, or optional/peer dependencies.  
 
-| **General** | [**Akairo**][akairo] | [**Commando**][commando] | [**Klasa**][klasa] | [**Komada**][komada] | [**YAMDBF**][yamdbf] |
-| --- | :-: | :-: | :-: | :-: | :-: |
-| Library version | 7.5.5 | 0.10.0 | 0.4.0 | 0.21.1 | 3.0.1 |
-| Discord.js version | `^11.4.0` | `^11.2.1` | Master branch | Master branch | Custom 11.1 |
-| Node.js version | 6.0.0 | 7.0.0 | 8.5.0 | 8.5.0 | 8.0.0 |
-| Typings | ✓ | ✓ | ✓ | ✘ | ✓ †1 |
-| Dependencies | 0 | 3 | 2 | 4 | 5 |
-| Documentation | [Akairo](https://1computer1.github.io/discord-akairo/) | [Commando](https://discord.js.org/#/docs/commando/master/general/welcome) | [Klasa](https://klasa.js.org/) | [Komada](https://komada.js.org/) | [YAMDBF](https://yamdbf.js.org/) |
-| VSCode Extension | ✘ | ? | ✓ | ✓ | ✘ |
+| **General** | [**Akairo**][akairo] | [**Commando**][commando] | [**YAMDBF**][yamdbf] |
+| --- | :-: | :-: | :-: |
+| Library version | 7.5.5 | 0.10.0 | 3.0.1 |
+| Discord.js version | `^11.4.0` | `^11.2.1` | Custom 11.1 |
+| Node.js version | 6.0.0 | 7.0.0 | 8.0.0 |
+| Typings | ✓ | ✓ | ✓ †1 |
+| Dependencies | 0 | 3 | 5 |
+| Documentation | [Akairo](https://1computer1.github.io/discord-akairo/) | [Commando](https://discord.js.org/#/docs/commando/master/general/welcome) | [YAMDBF](https://yamdbf.js.org/) |
+| VSCode Extension | ✘ | ? | ✘ |
 
 †1: YAMDBF is written in TypeScript.
 
@@ -26,14 +26,14 @@ Dependencies do not include Discord.js, TypeScript, or optional/peer dependencie
 Command parsing is how frameworks parse messages into commands.  
 This includes prefixes, aliases, etc.  
 
-| **Command Parsing** | [**Akairo**][akairo] | [**Commando**][commando] | [**Klasa**][klasa] | [**Komada**][komada] | [**YAMDBF**][yamdbf] |
-| --- | :-: | :-: | :-: | :-: | :-: |
-| Command aliases | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Mention as prefix | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Multiple prefixes | ✓ | ✘ | ✓ | ✓ | ✘ |
-| Per-guild prefix customisation | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Regular expression trigger | ✓ | ✓ | ✓ | ✓ | ✘ |
-| Stores original input | ✓ | ✓ | ✓ | ✓ | ✘ |
+| **Command Parsing** | [**Akairo**][akairo] | [**Commando**][commando] | [**YAMDBF**][yamdbf] |
+| --- | :-: | :-: | :-: |
+| Command aliases | ✓ | ✓ | ✓ |
+| Mention as prefix | ✓ | ✓ | ✓ |
+| Multiple prefixes | ✓ | ✘ | ✘ |
+| Per-guild prefix customisation | ✓ | ✓ | ✓ |
+| Regular expression trigger | ✓ | ✓ | ✘ |
+| Stores original input | ✓ | ✓ | ✘ |
 
 ## Command Handling
 
@@ -43,20 +43,18 @@ It also includes the monitoring of and the inhibition of messages and commands.
 Subcommands are commands that are individual commands with the same base name.  
 Argument parsing within one command does not count towards that criteria.  
 
-| **Command Handling** | [**Akairo**][akairo] | [**Commando**][commando] | [**Klasa**][klasa] | [**Komada**][komada] | [**YAMDBF**][yamdbf] |
-| --- | :-: | :-: | :-: | :-: | :-: |
-| Cooldowns | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Monitoring messages | ✓ | ✓ | ✓ | ✓ | ? |
-| Blocking messages | ✓ | ✓ | ✓ | ✓ | ? |
-| Channel restrictions | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Permissions restrictions | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Command edits | ✓ | ✓ | ✓ | ✓ | ? |
-| Subcommands | ✘ | ✘ | ✘ ⇒ ✓ | ✘ | ? |
-| Run from code | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Typing mode | ✓ | ? | ✓ | ✘ | ? |
-| Help information | ✓ | ✓ | ✓ | ✓ | ✓ |
-
-※1: Custom implementations only; see databases section.
+| **Command Handling** | [**Akairo**][akairo] | [**Commando**][commando] | [**YAMDBF**][yamdbf] |
+| --- | :-: | :-: | :-: |
+| Cooldowns | ✓ | ✓ | ✓ |
+| Monitoring messages | ✓ | ✓ | ? |
+| Blocking messages | ✓ | ✓ | ? |
+| Channel restrictions | ✓ | ✓ | ✓ |
+| Permissions restrictions | ✓ | ✓ | ✓ |
+| Command edits | ✓ | ✓ | ? |
+| Subcommands | ✘ | ✘ | ? |
+| Run from code | ✓ | ✓ | ✓ |
+| Typing mode | ✓ | ? | ? |
+| Help information | ✓ | ✓ | ✓ |
 
 ## Argument Parsing
 
@@ -68,70 +66,63 @@ Less obvious criterias:
 - Dependent arguments are arguments whose behavior depends on previous arguments.
 - User/member/role/channel matching means to be able to find an item based on approximations to their name, their ID, etc.
 
-| **Argument Parsing** | [**Akairo**][akairo] | [**Commando**][commando] | [**Klasa**][klasa] | [**Komada**][komada] | [**YAMDBF**][yamdbf] |
-| --- | :-: | :-: | :-: | :-: | :-: |
-| Ordered arguments | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Unordered arguments | ✘ ⇒ ✓ | ✘ | ✘ ⇒ ✓ | ✘ | ? |
-| Optional arguments | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Quoted arguments | ✓ | ✓ | ✓ | ✘ | ? |
-| Flag arguments | ✓ | ✘ | ✘ ⇒ ✓ | ✘ | ? |
-| Rest arguments | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Dependent arguments | ✓ | ✘ | ✘ ⇒ ✓ | ✘ | ? |
-| Argument types | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Union types | ✘ ⇒ ✓ | ✓ | ✓ | ✓ | ? |
-| Custom types | ✓ | ✓ | ✓ | ✓ | ✓ |
-| User and member matching | ✓ | ✓ | ※1 | ※2 | ✓ |
-| Role matching | ✓ | ✓ | ※1 | ※2 | ✓ |
-| Channel matching | ✓ | ✓ | ※1 | ※2 | ✓ |
-| Regular expression arguments | ✓ | ? | ✓ | ✘ | ? |
-| Custom arguments | ✓ | ✓ | ✓ | ✓ | ✓ |
-
-※1: Klasa only supports IDs and mentions.  
-※2: Komada only supports IDs and mentions.  
+| **Argument Parsing** | [**Akairo**][akairo] | [**Commando**][commando] | [**YAMDBF**][yamdbf] |
+| --- | :-: | :-: | :-: |
+| Ordered arguments | ✓ | ✓ | ✓ |
+| Unordered arguments | ✘ ⇒ ✓ | ✘ | ? |
+| Optional arguments | ✓ | ✓ | ✓ |
+| Quoted arguments | ✓ | ✓ | ? |
+| Flag arguments | ✓ | ✘ | ? |
+| Rest arguments | ✓ | ✓ | ✓ |
+| Dependent arguments | ✓ | ✘ | ? |
+| Argument types | ✓ | ✓ | ✓ |
+| Union types | ✘ ⇒ ✓ | ✓ | ? |
+| Custom types | ✓ | ✓ | ✓ |
+| User and member matching | ✓ | ✓ | ✓ |
+| Role matching | ✓ | ✓ | ✓ |
+| Channel matching | ✓ | ✓ | ✓ |
+| Regular expression arguments | ✓ | ? | ? |
+| Custom arguments | ✓ | ✓ | ✓ |
 
 ## Prompting
 
 Prompting is the ability to collect messages from the user without invoking a command directly.  
 Custom prompts do not count for other specific criterias, even if they are replicable.  
 
-| **Prompting** | [**Akairo**][akairo] | [**Commando**][commando] | [**Klasa**][klasa] | [**Komada**][komada] | [**YAMDBF**][yamdbf] |
-| --- | :-: | :-: | :-: | :-: | :-: |
-| From argument parsing | ✓ | ✓ | ✓ | ✓ | ? |
-| Prompt from code | ✓ | ✓ | ✘ ⇒ ✓ | ✘ | ? |
-| Prompt time limit | ✓ | ✓ | ✓ | ※4 | ? |
-| Prompt retry limit | ✓ | ✓ | ✘ ⇒ ✓ | ✘ | ? |
-| Prompt cancellation | ✓ | ✓ | ✓ | ✓ | ? |
-| Infinite prompts | ✓ | ✓ | ✓ | ✓ | ? |
-| Custom text prompt system | ✘ | ✘ | ✘ ⇒ ✓ | ✘ | ? |
-| Custom prompt messages | ✓ | ※1 | ✓ | ✘ | ? |
-| Stores prompts and replies | ※2 ⇒ ✓ | ※3 ⇒ ✓ | ※5 | ※5 | ? |
-| Reaction prompt system | ✘ | ? | ✓ | ✘ | ? |
+| **Prompting** | [**Akairo**][akairo] | [**Commando**][commando] | [**YAMDBF**][yamdbf] |
+| --- | :-: | :-: | :-: |
+| From argument parsing | ✓ | ✓ | ? |
+| Prompt from code | ✓ | ✓ | ? |
+| Prompt time limit | ✓ | ✓ | ? |
+| Prompt retry limit | ✓ | ✓ | ? |
+| Prompt cancellation | ✓ | ✓ | ? |
+| Infinite prompts | ✓ | ✓ | ? |
+| Custom text prompt system | ✘ | ✘ | ? |
+| Custom prompt messages | ✓ | ※1 | ? |
+| Stores prompts and replies | ※2 ⇒ ✓ | ※3 ⇒ ✓ | ? |
+| Reaction prompt system | ✘ | ? | ? |
 
 ※1: Commando appends built-in text to prompt messages.  
 ※2: Akairo stores only the last editable response.  
 ※3: Commando stores only the responses.  
-※4: Non-configurable time limit of 30 seconds.  
-※5: Klasa stores the raw args/parameters resolved.  
 
 ## Module System
 
 The module system of a framework is how the framework structures its modules.  
 This includes how new modules (e.g. commands) are created and loaded.  
 
-| **Module System** | [**Akairo**][akairo] | [**Commando**][commando] | [**Klasa**][klasa] | [**Komada**][komada] | [**YAMDBF**][yamdbf] |
-| --- | :-: | :-: | :-: | :-: | :-: |
-| Classes | ✓ | ✓ | ✓ | ✘ | ✓ |
-| Specific exports | ✘ | ✘ | ✘ | ✓ | ✘ |
-| ES module support | ✘ | ✘ | ✘ ⇒ ✓ †1 | ✘ | ✘ |
-| TypeScript module support | ✓ | ✓ | ✓ | ✘ | ✓ |
-| Recursive loading | ✓ | ✓ | ✓ | ✓ | ? |
-| Loading and unloading | ✓ | ✓ | ✓ | ✘ | ? |
-| Reloading modules | ✓ | ✓ | ✓ | ✓ | ? |
-| Module categories | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Custom module types | ✓ | ✘ | ✓ | ✘ | ? |
-| Plugins support | ✘ | ✘ | ✓ | ✓ | ✓ |
-
-†1: Klasa has experimental support for ESM in the `esm` branch from the repository.
+| **Module System** | [**Akairo**][akairo] | [**Commando**][commando] | [**YAMDBF**][yamdbf] |
+| --- | :-: | :-: | :-: |
+| Classes | ✓ | ✓ | ✓ |
+| Specific exports | ✘ | ✘ | ✘ |
+| ES module support | ✘ | ✘ | ✘ |
+| TypeScript module support | ✓ | ✓ | ✓ |
+| Recursive loading | ✓ | ✓ | ? |
+| Loading and unloading | ✓ | ✓ | ? |
+| Reloading modules | ✓ | ✓ | ? |
+| Module categories | ✓ | ✓ | ✓ |
+| Custom module types | ✓ | ✘ | ? |
+| Plugins support | ✘ | ✘ | ✓ |
 
 ## Databases
 
@@ -141,57 +132,54 @@ Custom settings do not count for other specific settings, even if they are repli
 
 Sequelize support does not count as SQLite, MySQL, MSSQL, or PostgreSQL support.
 
-| **Databases** | [**Akairo**][akairo] | [**Commando**][commando] | [**Klasa**][klasa] | [**Komada**][komada] | [**YAMDBF**][yamdbf] |
-| --- | :-: | :-: | :-: | :-: | :-: |
-| FireStore | ? | ? | ✓ †1 | ✘ | ? |
-| Level | ? | ? | ✓ †1 | ✘ | ? |
-| MongoDB | ✘ | ✘ | ✓ †1 | ✓ †2 | ? |
-| MSSQL | ✘ | ✘ | ✓ †1 | ✘ | ✓ |
-| MySQL | ✘ | ✘ | ✓ †1 | ✓ †2 | ✓ |
-| NeDB | ✘ | ? | ✓ †1 | ✓ †2 | ? |
-| Neo4J | ? | ? | ✓ †1 | ✘ | ? |
-| PostgreSQL | ✘ | ✘ | ✓ †1 | ✘ | ✓ |
-| RethinkDB | ✘ | ✘ | ✓ †1 | ✓ †2 | ? |
-| Sequelize | ✓ | ✘ | ✘ | ✘ | ✓ |
-| SQLite | ✓ | ✓ | ✓ †1 | ✓ †2 | ✓ |
-| Custom providers | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Disabled commands | ✘ | ✓ | ✓ | ✓ | ✓ |
-| Blacklist | ✘ | ✘ | ✘ ⇒ ✓ | ✘ | ✓ |
-| Prefixes | ✘ | ✓ | ✓ | ✓ | ✓ |
-| Localization | ✘ | ✘ | ✓ | ✘ | ✓ |
-| Custom settings | ✓ | ✓ | ✓ | ✓ | ✓ |
-
-†1: Klasa has official plugins for these databases on the [**Klasa Pieces Repo**](https://github.com/dirigeants/klasa-pieces).  
-†2: Komada has official plugins for these databases on the [**Komada Pieces Repo**](https://github.com/dirigeants/komada-pieces).  
+| **Databases** | [**Akairo**][akairo] | [**Commando**][commando] | [**YAMDBF**][yamdbf] |
+| --- | :-: | :-: | :-: |
+| FireStore | ? | ? | ? |
+| Level | ? | ? | ? |
+| MongoDB | ✘ | ✘ | ? |
+| MSSQL | ✘ | ✘ | ✓ |
+| MySQL | ✘ | ✘ | ✓ |
+| NeDB | ✘ | ? | ? |
+| Neo4J | ? | ? | ? |
+| PostgreSQL | ✘ | ✘ | ✓ |
+| RethinkDB | ✘ | ✘ | ? |
+| Sequelize | ✓ | ✘ | ✓ |
+| SQLite | ✓ | ✓ | ✓ |
+| Custom providers | ✓ | ✓ | ✓ |
+| Disabled commands | ✘ | ✓ | ✓ |
+| Blacklist | ✘ | ✘ | ✓ |
+| Prefixes | ✘ | ✓ | ✓ |
+| Localization | ✘ | ✘ | ✓ |
+| Custom settings | ✓ | ✓ | ✓ | 
 
 ## Events
 
 Events that are useful for a framework are compared here.
 
-| **Events** | [**Akairo**][akairo] | [**Commando**][commando] | [**Klasa**][klasa] | [**Komada**][komada] | [**YAMDBF**][yamdbf] |
-| --- | :-: | :-: | :-: | :-: | :-: |
-| Modular event listeners | ✓ | ✘ | ✓ | ✓ | ? |
-| Reloadable event structures | ✓ | ? | ✓ | ✓ | ? |
-| On invalid commands | ✓ | ✓ | ✓ | ✘ | ? |
-| On command blocked | ✓ | ✓ | ✓ | ✘ | ? |
-| On command start | ✓ | ✓ | ✘ ⇒ ✓ | ✘ | ? |
-| On command end | ✓ | ✘ | ✓ | ✘ | ? |
-| On command error | ✓ | ✓ | ✓ | ✘ | ? |
-| On database changes | ✘ | ✘ | ✓ | ✓ | ? |
-| On module changes | ✓ | ✓ | ✓ | ✘ | ? |
-| Custom events | ✓ | ? | ✓ | ✓ | ✓ |
+| **Events** | [**Akairo**][akairo] | [**Commando**][commando] | [**YAMDBF**][yamdbf] |
+| --- | :-: | :-: | :-: |
+| Modular event listeners | ✓ | ✘ | ? |
+| Reloadable event structures | ✓ | ? | ? |
+| On invalid commands | ✓ | ✓ | ? |
+| On command blocked | ✓ | ✓ | ? |
+| On command start | ✓ | ✓ | ? |
+| On command end | ✓ | ✘ | ? |
+| On command error | ✓ | ✓ | ? |
+| On database changes | ✘ | ✘ | ? |
+| On module changes | ✓ | ✓ | ? |
+| Custom events | ✓ | ? | ✓ |
 
 ## Promise Support
 
 Support for Promises, either as return values from the user or as implementations internally.
 
-| **Promise Support** | [**Akairo**][akairo] | [**Commando**][commando] | [**Klasa**][klasa] | [**Komada**][komada] | [**YAMDBF**][yamdbf] |
-| --- | :-: | :-: | :-: | :-: | :-: |
-| Promises used internally | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Message monitoring | ✓ | ✘ | ✓ | ✓ | ? |
-| Argument parsing | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Command restrictions | ✘ ⇒ ✓ | ✘ | ✓ | ✘ | ✓ |
-| Command execution | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Promise Support** | [**Akairo**][akairo] | [**Commando**][commando] | [**YAMDBF**][yamdbf] |
+| --- | :-: | :-: | :-: |
+| Promises used internally | ✓ | ✓ | ✓ |
+| Message monitoring | ✓ | ✘ | ? |
+| Argument parsing | ✓ | ✓ | ✓ |
+| Command restrictions | ✘ ⇒ ✓ | ✘ | ✓ |
+| Command execution | ✓ | ✓ | ✓ |
 
 ## Settings
 
@@ -200,17 +188,17 @@ They are used to opt-in or opt-out of built-in features.
 
 Built-in features marked as `✓` means they exist and are modifiable, `✘` means they exist and are not modifiable, and `∅` means they do not exist.
 
-| **Settings** | [**Akairo**][akairo] | [**Commando**][commando] | [**Klasa**][klasa] | [**Komada**][komada] | [**YAMDBF**][yamdbf] |
-| --- | :-: | :-: | :-: | :-: | :-: |
-| Modifiable built-in commands | ∅ | ✘ | ✓ | ✓ | ✓ |
-| Modifiable built-in event handlers | ∅ | ? | ✓ | ✓ | ? |
-| Modifiable built-in inhibitors | ✘ | ? | ✓ | ✓ | ? |
-| Modifiable built-in command handler | ✓ | ? | ✓ | ✓ | ? |
-| Modifiable built-in responses | ✓ ⇒ ∅ | ✘ | ✓ | ✘ | ✓ |
-| Modifiable built-in locales | ∅ | ∅ | ✓ | ∅ | ✓ |
-| Bot owner | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Multiple owners | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Module directories | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Settings** | [**Akairo**][akairo] | [**Commando**][commando] | [**YAMDBF**][yamdbf] |
+| --- | :-: | :-: | :-: |
+| Modifiable built-in commands | ∅ | ✘ | ✓ |
+| Modifiable built-in event handlers | ∅ | ? | ? |
+| Modifiable built-in inhibitors | ✘ | ? | ? |
+| Modifiable built-in command handler | ✓ | ? | ? |
+| Modifiable built-in responses | ✓ ⇒ ∅ | ✘ | ✓ |
+| Modifiable built-in locales | ∅ | ∅ | ✓ |
+| Bot owner | ✓ | ✓ | ✓ |
+| Multiple owners | ✓ | ✓ | ✓ |
+| Module directories | ✓ | ✓ | ✓ |
 
 ## Legend
 
@@ -246,7 +234,4 @@ Official plugins are to be labelled with a `✓`, along with a note as to where 
 
 [akairo]: https://www.npmjs.com/package/discord-akairo
 [commando]: https://www.npmjs.com/package/discord.js-commando
-[handles]: https://www.npmjs.com/package/discord-handles
-[klasa]: https://www.npmjs.com/package/klasa
-[komada]: https://www.npmjs.com/package/komada
 [yamdbf]: https://www.npmjs.com/package/yamdbf


### PR DESCRIPTION
Fixes #10. 

**Removes Komada because:**
- The framework has been unmaintained and unsupported for over 2 years, there are no official channels.

**Removes Klasa because:**
- The framework uses its own library (namely [`@klasa/core`](https://www.npmjs.com/package/@klasa/core)) over discord.js, which makes it not longer qualify as a discord.js framework.